### PR TITLE
Exclude some fields from the output

### DIFF
--- a/table.go
+++ b/table.go
@@ -93,6 +93,9 @@ func parse(slice interface{}) (
 			ct := t.Field(n).Tag.Get("table")
 			if ct == "" {
 				ct = cn
+			} else if ct == "-" {
+				m++
+				continue
 			}
 			cv := fmt.Sprintf("%+v", v.FieldByName(cn).Interface())
 


### PR DESCRIPTION
Set the table tag to "-".
Fields that are set are excluded from the output.